### PR TITLE
Setup and teardown changes/restores recaptcha settings

### DIFF
--- a/apps/drumbeatmail/tests.py
+++ b/apps/drumbeatmail/tests.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from users.models import UserProfile
 from drumbeatmail.forms import ComposeForm
 from relationships.models import Relationship
@@ -26,6 +28,13 @@ class TestDrumbeatMail(test_utils.TestCase):
         self.user_two.set_password('testpassword')
         self.user_two.save()
         self.user_two.create_django_user()
+        self.old_recaptcha_pubkey = settings.RECAPTCHA_PUBLIC_KEY
+        self.old_recaptcha_privkey = settings.RECAPTCHA_PRIVATE_KEY
+        settings.RECAPTCHA_PUBLIC_KEY, settings.RECAPTCHA_PRIVATE_KEY = '', ''
+        
+    def tearDown(self):
+        settings.RECAPTCHA_PUBLIC_KEY = self.old_recaptcha_pubkey
+        settings.RECAPTCHA_PRIVATE_KEY = self.old_recaptcha_privkey
 
     def test_messaging_user_following(self):
         print "From test: %s" % (self.user.user,)

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,5 +1,6 @@
 from django.test import Client
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.conf import settings
 
 from l10n.urlresolvers import reverse
 from drumbeat.utils import get_partition_id
@@ -22,6 +23,13 @@ class TestLogins(TestCase):
         self.user.set_password(self.test_password)
         self.user.save()
         self.user.create_django_user()
+        self.old_recaptcha_pubkey = settings.RECAPTCHA_PUBLIC_KEY
+        self.old_recaptcha_privkey = settings.RECAPTCHA_PRIVATE_KEY
+        settings.RECAPTCHA_PUBLIC_KEY, settings.RECAPTCHA_PRIVATE_KEY = '', ''
+        
+    def tearDown(self):
+        settings.RECAPTCHA_PUBLIC_KEY = self.old_recaptcha_pubkey
+        settings.RECAPTCHA_PRIVATE_KEY = self.old_recaptcha_privkey
 
     def test_authenticated_redirects(self):
         """Test that authenticated users are redirected in specific views."""


### PR DESCRIPTION
This makes tests pass regardless of local recaptcha settings.
