### PR TITLE
IE7 Splash Page Display Issue Fix

### DIFF
--- a/media/css/batucada.css
+++ b/media/css/batucada.css
@@ -1748,7 +1748,7 @@ header {}
 	font: normal 42px/44px MuseoSans-500, sans-serif;
 	color: #fff;
 	text-shadow: none;
-        padding-top: 30px;
+	padding-top: 30px;
 }
 #splash #content header h1{
   color: #a9b2c1;
@@ -1757,7 +1757,7 @@ header {}
   line-height: 65px;
   text-transform: uppercase;
   padding-left: 10px;
-  width: 720px;
+  width: 690px;
   height: 200px;
   overflow: visible;
 }
@@ -1787,8 +1787,8 @@ header {}
 	right: 81px; bottom: -105px;
 	}
 #splash #main{
-        width: 980px;
-        padding: 36px 10px 0 10px;
+	width: 980px;
+	padding: 36px 10px 0 10px;
 	margin: 0;
 	float: none;
 	border-top: 1px solid #fff;
@@ -1797,8 +1797,7 @@ header {}
 	display: none;
 	}
 #splash #main aside {
-	display: block;
-	margin-left: 680px;
+	float:right;
 	}	
 #splash #main aside > section > h1{
 	position: relative;
@@ -1808,7 +1807,7 @@ header {}
 	font-size: 16px;
 	line-height: 18px;
 	font-weight: normal;
-        width: 300px;
+	width: 300px;
 	border-bottom: 1px solid #dbdbdb;
 	}
 #splash #featured_project ul {

--- a/templates/dashboard/splash.html
+++ b/templates/dashboard/splash.html
@@ -20,13 +20,8 @@
   </div>
 </header> <!-- /#intro -->
 <section id="main">
-  <div class="container">
-    <ul id="posts">
-      {% for activity in activities %}
-        {% include "activity/_activity_resource.html" %}
-      {% endfor %}
-    </ul>
-    <aside>
+  <div class="container clearfix">
+	<aside>
     	{% if featured_project %}
       <section id="featured_project" class="card-list">
         <h1>{{ _('Featured') }}</h1>
@@ -37,6 +32,12 @@
         </ul>
       </section>
     	{% endif %}
+	</aside>
+    <ul id="posts">
+      {% for activity in activities %}
+        {% include "activity/_activity_resource.html" %}
+      {% endfor %}
+    </ul>
   </div>  
 </section>
 {% endblock %}


### PR DESCRIPTION
This should hopefully resolve the IE7 display issues on the splash page.

1) I basically made the splash page h1 heading a width that didn't encroach on the nav#intro-links
2) I moved the aside before the #posts and floated it right instead of having a oversize margin-left that tried to force it beyond the page's width.

Note: I am new to Python, so I was not able to run the project and test these changes locally. However, this simple adjustment displayed properly in firebug, so I am hoping it will work.  I will look to get Python running locally for my next pull request.
