### PR TITLE
Updating profile title to show username

### DIFF
--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -2,7 +2,7 @@
 {% load l10n_tags %}
 {% load i18n %}
 {% load truncate_chars %}
-{% block title %}{{ profile.name }}{% endblock %}
+{% block title %}{{ profile.username }}{% endblock %}
 
 {% block links %}
 <link rel="alternate" type="application/atom+xml" href="{% locale_url activity_user_feed username=profile.username %}">


### PR DESCRIPTION
When you visit a user profile (for example http://new.p2pu.org/en/nando/), the title bar says Lernanta |. With this change, it should say Lernanta | nando. 

This is in reference to this ticket:
http://p2pu.lighthouseapp.com/projects/71002/tickets/226-username-in-title-on-user-profile-page#ticket-226-7
