### PR TITLE
Changing compiled requirements to match prod requirements

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,3 +1,3 @@
 MySQL-python==1.2.3c1
 PIL==1.1.7
-lxml==2.3beta1
+lxml==2.3


### PR DESCRIPTION
The instructions say to install prod after compiled, so most people have been running with lxml==2.3 anyway.
