### PR TITLE
Ticket #180: Label separation on page headings

### DIFF
--- a/templates/content/edit_page.html
+++ b/templates/content/edit_page.html
@@ -21,7 +21,7 @@
 
 
 {% block page_form_title %}
-  <h1>{{ _('Edit') }} {{ page.title }}</h1>
+  <h1>[{{ _('Edit') }}] {{ page.title }}</h1>
 {% endblock %}
 
 {% block page_form_url %}

--- a/templates/content/history_page.html
+++ b/templates/content/history_page.html
@@ -30,7 +30,7 @@
 {% block body %}
 {% sidebar %}
 <div id="main" class="content_page">
-<h1>{{ _('History') }} {{ page.title }}</h1>
+<h1>[{{ _('History') }}] {{ page.title }}</h1>
 <hr />
 <ul>
   {% if page.deleted %}

--- a/templates/content/version_page.html
+++ b/templates/content/version_page.html
@@ -37,7 +37,7 @@
 {% block body %}
 {% sidebar %}
 <div id="main" class="content_page">
-<h1>{{ version.title }} {{ version.date }}</h1>
+<h1>{{ version.title }} [{{ version.date }}]</h1>
 <hr />
 {{ version.content|youtube|slideshare|safe }}
 </div>


### PR DESCRIPTION
I think this is going to be an interim solution for - I added square brackets around the 'edit' and 'history' labels, as well as around the date on the version page. I think wrapping the labels (and date) in a div is a more robust solution, but maybe this will be good enough for now? If you want me to rather pursue the div solution, then just let me know, and don't worry about committing this. I just ran out of time so wanted to try and at least get something in :-)
