### PR TITLE
Adding "-f" to "rm" to suppress error messages

### DIFF
--- a/sh/rmpyc
+++ b/sh/rmpyc
@@ -1,1 +1,1 @@
-rm `find . -name '*.pyc'`
+rm -f `find . -name '*.pyc'`


### PR DESCRIPTION
in the "sh/rmpyc" utility script.
