### PR TITLE
Fix to bug #476.  

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
   <!--[if IE]><meta content='IE=8' http-equiv='X-UA-Compatible'/><![endif]-->
 
   <title>P2PU (beta) | {% block title %}{% endblock %}</title>
-  <meta name="description" content="{{ _('Learning for everyone, by everyone, about almost anything.') }}">
+  <meta name="description" content="{% block description %}{{ _('Learning for everyone, by everyone, about almost anything.') }}{% endblock %}">
   <meta name="author" content="mozilla">
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/templates/projects/base.html
+++ b/templates/projects/base.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load l10n_tags %}
 
+{% block description %}{{ project.name }}: {{ project.short_description|safe }}{% endblock %}
 {% block title %}{{ project.name }} | {% block project_title %}{% endblock %}{% endblock %}
 
 {% block links %}


### PR DESCRIPTION
Meta description on group page now includes the project name, and the short description.
