### PR TITLE
Feature 320

### DIFF
--- a/templates/users/forgot_password.html
+++ b/templates/users/forgot_password.html
@@ -10,7 +10,7 @@
       <form action="{% locale_url users_forgot_password %}" method="post">
         {% csrf_token %}
         <div class="field{% if form.email.errors %} error{% endif %}">
-          <label for="id_email">{{ _('Email Address') }}</label>
+          <label for="id_email">{{ _('Username or Email') }}</label>
           {{ form.email }}
           {{ form.email.errors }}
         </div>


### PR DESCRIPTION
Now the password recovery form accepts an username (even though the variable in the code still says "email").

Missing translation for one of the error messages. ("Username not found.")
