### PR TITLE
Disable recaptcha for direct messages replies

### DIFF
--- a/lernanta/templates/drumbeatmail/base.html
+++ b/lernanta/templates/drumbeatmail/base.html
@@ -23,6 +23,7 @@
 	  {{ form.body }}
 	  {{ form.body.errors }}
 	</div>
+	{% block recaptcha%} 
         {% if settings.RECAPTCHA_PRIVATE_KEY %}
           <div class="field{% if form.recaptcha.errors %} error{% endif %}">
              <!-- Note: though recaptcha is localized the "Play sound again" and "Download sound as MP3" are in English -->
@@ -34,6 +35,7 @@
             {{ _('Welcome Robots, ReCaptcha has been disabled for your convenience. Spam at will.') }}
           </p>
         {% endif %}
+    {%endblock%}
 	<p class="buttons">
 	  <a class="button" href="{% locale_url drumbeatmail_inbox %}">{{ _('Cancel') }}</a>
 	  <button type="submit" value="{{ _('Send') }}">{{ _('Send') }}</button>
@@ -55,4 +57,3 @@
     <script type="text/javascript" src="{{ settings.RECAPTCHA_URL }}"></script>
  {% endif %}
 {% endblock %}
-

--- a/lernanta/templates/drumbeatmail/reply.html
+++ b/lernanta/templates/drumbeatmail/reply.html
@@ -5,3 +5,4 @@
 {% block bodyid %}reply{% endblock %}
 {% block heading %}{{ _('Reply') }}{% endblock %}
 {% block action %}{% locale_url drumbeatmail_reply message=message.id %}{% endblock %}
+{% block recaptcha%} {%endblock%}


### PR DESCRIPTION
Hello,

My team and I manage to fix that error by adding a blank block in template > drumbeatmail > reply.html.
Using that block to omit the recaptcha block  in template > drumbeatmail > base.html.

http://p2pu.lighthouseapp.com/projects/71002/tickets/462-disable-recaptcha-for-direct-messages-replies
