### PR TITLE
Use Django to serve static files when DEBUG=True.

### DIFF
--- a/lernanta/urls.py
+++ b/lernanta/urls.py
@@ -37,5 +37,13 @@ urlpatterns += patterns('',
      }),
 )
 
+static_url = settings.STATIC_URL.lstrip('/').rstrip('/')
+urlpatterns += patterns('',
+    (r'^%s/(?P<path>.*)$' % static_url, 'django.views.static.serve',
+     {
+         'document_root': settings.STATIC_ROOT,
+     }),
+)
+
 handler500 = 'drumbeat.views.server_error'
 handler404 = 'drumbeat.views.page_not_found'


### PR DESCRIPTION
Need to run ./manage.py collectstatic in newly cloned repo, and to update with new static files; for example after installing a new module that includes static files such as JavaScript and CSS.

Copied the code for media_url and replaced "media" with "static".

Fixes issue #133 .
