### PR TITLE
Challenge: don't show completed users as participants.

### DIFF
--- a/lernanta/templates/projects/_user_list.html
+++ b/lernanta/templates/projects/_user_list.html
@@ -57,11 +57,11 @@
       <hr class="break">
       <h3 class="peers-challenge">{{ _('Peers taking this challenge') }}</h3>
       <br>
-      {% for participant in participants %}
+      {% for participant in participants_not_completed %}
         <a href="{{ participant.user.get_absolute_url }}" title="{{ participant.user }}"><img class="member-picture" src="{{ participant.user.image_or_default }}" height="40" width="40" alt="{{ participant.user }}"></a>
       {% endfor %}
       {% if paginate_sections %}
-        {% with prefix='participants_' page_url=user_list_url %}
+        {% with prefix='participants_not_completed_' page_url=user_list_url %}
           {% pagination_links %}
         {% endwith %}
       {% endif %}


### PR DESCRIPTION
This PR address issue #127 .

Display page for a challenge shows help providers, participants, and people who have completed the challenge. The participant list included people who have completed the challenge.

We want to list only those who haven't completed the challenge in the participants list.

A simple "exclude" filter applied in project_tags to create a list "participants_not_completed". I inserted this in what I think are the appropriate locations in projects/_user_list.html.

I tested this using the

http://127.0.0.1:8000/en/groups/test-webmaking-101-7/

challenge that was created using the Django "loaddata" command, on the data in projects/fixtures.

See http://i.imgur.com/W1DSv.png .

