### PR TITLE
Fix template rendering error on school edit pages.

### DIFF
--- a/lernanta/templates/schools/school_edit_background.html
+++ b/lernanta/templates/schools/school_edit_background.html
@@ -16,7 +16,7 @@
   <p class="hint">{{ _('Upload an image file from your computer:') }}</p>  
   <div class="field{% if form.background.errors %} error{% endif %}">
     <input type="file" name="background" id="id_background"/>
-    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only')<br/> _('Max size:') _('700k') <br/> _('Dimensions:') _('20x60 pixels') }}</small>
+    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only') }}<br/> {{ _('Max size:') }} {{ _('700k') }} <br/> {{ _('Dimensions:') }} {{ _('20x60 pixels') }}</small>
     {{ form.background.errors }}
   </div>
   <p class="buttons">

--- a/lernanta/templates/schools/school_edit_groups_icon.html
+++ b/lernanta/templates/schools/school_edit_groups_icon.html
@@ -16,7 +16,7 @@
   <p class="hint">{{ _('Upload an image file from your computer:') }}</p>  
   <div class="field{% if form.groups_icon.errors %} error{% endif %}">
     <input type="file" name="groups_icon" id="id_groups_icon"/>
-    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only')<br/> _('Max size:') _('700k') <br/> _('Dimensions:') _('41x50 pixels') }}</small>
+    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only') }}<br/> {{ _('Max size:') }} {{ _('700k') }} <br/> {{ _('Dimensions:') }} {{ _('41x50 pixels') }}</small>
     {{ form.groups_icon.errors }}
   </div>
   <p class="buttons">

--- a/lernanta/templates/schools/school_edit_logo.html
+++ b/lernanta/templates/schools/school_edit_logo.html
@@ -16,7 +16,7 @@
   <p class="hint">{{ _('Upload an image file from your computer:') }}</p>  
   <div class="field{% if form.logo.errors %} error{% endif %}">
     <input type="file" name="logo" id="id_logo"/>
-    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only')<br/> _('Max size:') _('700k') <br/> _('Dimensions:') _('Variable') }}</small>
+    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only') }}<br/> {{ _('Max size:') }} {{ _('700k') }} <br/> {{ _('Dimensions:') }} {{ _('Variable') }}</small>
     {{ form.logo.errors }}
   </div>
   <p class="buttons">

--- a/lernanta/templates/schools/school_edit_site_logo.html
+++ b/lernanta/templates/schools/school_edit_site_logo.html
@@ -16,7 +16,7 @@
   <p class="hint">{{ _('Upload an image file from your computer:') }}</p>  
   <div class="field{% if form.site_logo.errors %} error{% endif %}">
     <input type="file" name="site_logo" id="id_site_logo"/>
-    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only')<br/> _('Max size:') _('700k') <br/> _('Dimensions:') _('141x44 pixels') }}</small>
+    <small class="hint block">{{ _('File Types: JPG, GIF or PNG only') }}<br/> {{ _('Max size:') }} {{ _('700k') }} <br/> {{ _('Dimensions:') }} {{ _('141x44 pixels') }}</small>
     {{ form.logo.errors }}
   </div>
   <p class="buttons">


### PR DESCRIPTION
Surrounded each translation tag with braces. No longer raises a template rendering error.
