### PR TITLE
Handle user profile image upload without an image

### DIFF
--- a/lernanta/apps/users/forms.py
+++ b/lernanta/apps/users/forms.py
@@ -252,7 +252,7 @@ class ProfileImageForm(forms.ModelForm):
         fields = ('image',)
 
     def clean_image(self):
-        if self.cleaned_data['image'] is False:
+        if not self.cleaned_data['image']:
             return self.cleaned_data['image']
         if self.cleaned_data['image'].size > settings.MAX_IMAGE_SIZE:
             max_size = settings.MAX_IMAGE_SIZE / 1024


### PR DESCRIPTION
The image upload button on the profile edit pages threw a 505 if clicked without an image to upload.
